### PR TITLE
Fix community list being comma-separated

### DIFF
--- a/lemmyTools.js
+++ b/lemmyTools.js
@@ -778,7 +778,7 @@ if (url.includes(settings.theInstance)) {
     communityArray.forEach(_ => count++);
   }
 
-  div.innerHTML += communityArray;
+  div.innerHTML += communityArray.join('');
   if (div.innerHTML.length >= 20) {
 console.log("LemmyTools: Got Results >20");
 
@@ -786,15 +786,15 @@ console.log("LemmyTools: Got Results >20");
       localStorage.setItem("localComms", communityArray);
 			localStorage.setItem("commsCount", count);
     //force update the page
-    searchComms("", communityArray, div);
+    searchComms("", communityArray.join(''), div);
 
   } else {
     console.log("LemmyTools: " + "get localcomms from localstore");
     communityArray = localStorage.getItem("localComms");
 
-    div.innerHTML += communityArray;
+    div.innerHTML += communityArray.join('');
     //force update the page
-    searchComms("", communityArray, div);
+    searchComms("", communityArray.join(''), div);
   }
 
 


### PR DESCRIPTION
The issue was that the array of communities is supplied to innerHTML, which by default seems to call `.join()` which defaults to `,` as separator. Instead, what we want is `.join('')` as the array contains HTML list elements anyway.

This still has bugs and should not be merged yet ;)