### PR TITLE
Added ability to scale images via pixel or percernt, other fixes [REDUX]

### DIFF
--- a/lemmyTools.js
+++ b/lemmyTools.js
@@ -286,7 +286,7 @@ If you don’t see your subscribed communities here, simply login to your lemmy 
   //Expand all images on page
   function allImages(show) {
     let clickableImages = document.getElementsByClassName(
-      "overflow-hidden pictrs-image img-fluid thumbnail rounded object-fit-cover"
+      "thumbnail rounded overflow-hidden d-inline-block position-relative p-0 border-0 bg-transparent"
     );
 
     //ltLog(clickableImages.length, LogDebug);
@@ -294,6 +294,8 @@ If you don’t see your subscribed communities here, simply login to your lemmy 
     if (show) {
       for (let i = 0; i < clickableImages.length; i++) {
         try {
+          console.log(clickableImages[i]);
+
           clickableImages[i].click();
         } catch {}
       }
@@ -365,8 +367,8 @@ If you don’t see your subscribed communities here, simply login to your lemmy 
         url = document.location.href;
         if (settings.showAllImages) {
           // todo there has to be a better way to wait for the content to be loaded …
-          var imagesTimer = setTimeout( allImages, 5000);
-          clearTimeout(imagesTimer)
+          var imagesTimer = setTimeout(allImages, 5000);
+          clearTimeout(imagesTimer);
           //allImages(true);
         }
       }
@@ -972,7 +974,7 @@ If you don’t see your subscribed communities here, simply login to your lemmy 
         });
       }
     } catch {}
-  	//Links Open In New Tab
-		linksInNewTab();
+    //Links Open In New Tab
+    linksInNewTab();
   }, 500);
 })();

--- a/lemmyTools.js
+++ b/lemmyTools.js
@@ -451,10 +451,7 @@ If you don’t see your subscribed communities here, simply login to your lemmy 
             <br />Defaults - Desktop: On / Mobile: Off <br /><br /> Post width / comment width setting in pixels.
             Increase or Decrease to your reading preference while viewing posts. (Default 740) </td>
           <td><input type='checkbox' id='option_alienSiteOld' ${aSOcheck} /><br /><br /><br /><textarea
-              id='option_alienSiteOldReadWidth'>${settings.alienSiteOldReadWidth}</textarea>
-              <br /> <label for="option_widthPixels">Pixels</label> <input type='radio' id='option_widthPixels' name="widthScaler" ${widthPixelCheck}/> 
-              <label for="option_widthPercent">Percent</label> <input type='radio' id='option_widthPercent' name="widthScaler" ${widthPercentCheck}/>
-              </td>
+              id='option_alienSiteOldReadWidth'>${settings.alienSiteOldReadWidth}</textarea></td>
         </tr>
         <tr>
           <td><b>Hide Lemmy Sidebars</b><br /> (Trending, ServerInfo, Communities)<br /> More room for images on feed.
@@ -469,7 +466,10 @@ If you don’t see your subscribed communities here, simply login to your lemmy 
         <tr>
           <td><b>Auto Expand Size</b><br />Size of post image after opening a image post.<br /> Desktop Default: 50 /
             Mobile: 100</td>
-          <td><textarea id='option_expandImagesize'>${settings.expandImagesize}</textarea></td>
+          <td><textarea id='option_expandImagesize'>${settings.expandImagesize}</textarea>
+          <br /> <label for="option_widthPixels">Pixels</label> <input type='radio' id='option_widthPixels' name="widthScaler" ${widthPixelCheck}/> 
+          <label for="option_widthPercent">Percent</label> <input type='radio' id='option_widthPercent' name="widthScaler" ${widthPercentCheck}/>
+          </td>
         </tr>
         <tr>
           <td><b>Expand Image Speed</b><br />Speed multiplier for click&drag expanding images. If your images seem to

--- a/lemmyTools.js
+++ b/lemmyTools.js
@@ -299,13 +299,13 @@ If you don’t see your subscribed communities here, simply login to your lemmy 
       }
     } else {
       //lazy - need to figure out way to handle on dom iter
-      //location.reload(true);
-      for (let i = 0; i < clickableImages.length; i++) {
-        try {
-          clickableImages[i].click();
-          clickableImages[i].click();
-        } catch {}
-      }
+      location.reload(true);
+      // for (let i = 0; i < clickableImages.length; i++) {
+      //   try {
+      //     clickableImages[i].click();
+      //     clickableImages[i].click();
+      //   } catch {}
+      // }
     }
   }
 


### PR DESCRIPTION
- fixed "show all images" glitch in my other PR that caused images AND links to open (oops)
- added ability to scale images via percent or pixel
- disabled offset removal if image scaling is off because I personally did not like it lol
- changed i = i+2 to i++ in the allimages() function because it was skipping some photos
- removed .show() from the allimages() function because it was unnecessary

